### PR TITLE
LB-542: Embed URL can't be opened in IE8 and IE9

### DIFF
--- a/plugins/livedesk-embed/gui-resources/scripts/js/core/utils/ie-polyfill.js
+++ b/plugins/livedesk-embed/gui-resources/scripts/js/core/utils/ie-polyfill.js
@@ -1,0 +1,34 @@
+define(function(){
+	if (!Array.prototype.indexOf) {
+			Array.prototype.indexOf = function (searchElement /*, fromIndex */ ) {
+				"use strict";
+				if (this === void 0 || this === null) {
+					throw new TypeError();
+				}
+				var t = Object(this);
+				var len = t.length >>> 0;
+				if (len === 0) {
+					return -1;
+				}
+				var n = 0;
+				if (arguments.length > 0) {
+					n = Number(arguments[1]);
+		            if (n !== n) { // shortcut for verifying if it's NaN
+		            	n = 0;
+		        } else if (n !== 0 && n !== Infinity && n !== -Infinity) {
+		        	n = (n > 0 || -1) * Math.floor(Math.abs(n));
+		        }
+		    }
+		    if (n >= len) {
+		    	return -1;
+		    }
+		    var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
+		    for (; k < len; k++) {
+		    	if (k in t && t[k] === searchElement) {
+		    		return k;
+		    	}
+		    }
+		    return -1;
+		}
+	}
+});

--- a/plugins/livedesk-embed/gui-resources/scripts/js/views/timeline.js
+++ b/plugins/livedesk-embed/gui-resources/scripts/js/views/timeline.js
@@ -3,6 +3,7 @@ define([
 	'gizmo/view-events',
 	'livedesk-embed/views/post',
 	'utils/date-format',
+	'utils/ie-polyfill',
 	'livedesk-embed/dispatcher',
 	'jquery/tmpl',
 	'jquery/scrollspy',


### PR DESCRIPTION
Fixed with a polyfill. From what I saw the problem was just in IE8
