### PR TITLE
NR-904 art search names

### DIFF
--- a/plugins/content-article/content/article/impl/db_search.py
+++ b/plugins/content-article/content/article/impl/db_search.py
@@ -55,7 +55,7 @@ class SqlArticleSearchProvider(IArticleSearchProvider):
             sql = sql.join(UserMapped, ArticleMapped.Creator == UserMapped.Id)
 
             if QArticle.search in q:
-                all = processLike(q.search.all)
+                all = processLike(q.search.like if q.search.like else q.search.ilike)
                 # TODO: Notice that the "UserMapped.Name" part is for login names.
                 #       It should not be used when doing a search for outer readers.
                 sql = sql.filter(or_(PersonMapped.FullName.like(all), UserMapped.Name.like(all), UserMapped.FullName.like(all), ArticleMapped.Content.like(all)))


### PR DESCRIPTION
Article search uses login names as well. Beware that this should not be used for search by external readers.
