### PR TITLE
LB-659: clicking on Publish for certain FB posts leads to error

### DIFF
--- a/plugins/livedesk/gui-resources/scripts/js/providers/facebook/adaptor.js
+++ b/plugins/livedesk/gui-resources/scripts/js/providers/facebook/adaptor.js
@@ -25,7 +25,7 @@ define([
                     sourceTemplate: 'sources/facebook',
                     data: {
                         Creator: localStorage.getItem('superdesk.login.id'),
-                        Content: obj.message,
+                        Content: null,
                         Type: 'normal',
                         Author: this.author,
                         Meta: meta


### PR DESCRIPTION
Fix content length error - content was sent twice, now it's only
part of meta object.
