### PR TITLE
LB-729: Pinterest share error

### DIFF
--- a/plugins/livedesk-embed/gui-resources/scripts/js/views/post.js
+++ b/plugins/livedesk-embed/gui-resources/scripts/js/views/post.js
@@ -188,6 +188,9 @@ define([
 							var blogTitle = encodeURL(self._parent.model.get('Title'));
 							var myPerm = encodeURL(data.permalink);
 							var imgsrc = $('.result-content img:first', self.el).attr('src');
+							if ( !imgsrc ) {
+								var imgsrc = $('img:first').attr('src');
+							}
 							var summary = encodeURL($('.result-content .result-text:last', self.el).text());
 							var pinurl = "http://pinterest.com/pin/create/button/?url=" + myPerm + "&media=" + imgsrc + "&description=" + blogTitle;
 							var gglurl = "https://plus.google.com/share?url=" + myPerm + "&t=";


### PR DESCRIPTION
Quick fixed. The error is generated when there is no image to share on
that post. In such cases I just pick the first image available
