### PR TITLE
LB-882: Arrow for choosing feeds type won't work after switching back from Configure Blog

### DIFF
--- a/plugins/livedesk/gui-resources/scripts/js/edit-live-blogs.js
+++ b/plugins/livedesk/gui-resources/scripts/js/edit-live-blogs.js
@@ -787,6 +787,7 @@ function(providers, Gizmo, $, BlogAction, upload, router)
 		EditView = Gizmo.View.extend
 		({
 			timelineView: null,
+			namespace: 'edit-view',
 			events: 
 			{
 				'[is-content] section header h2': { focusout: 'save' },


### PR DESCRIPTION
Fixed
