### PR TITLE
LB-1797: Add css class for instagram tags

### DIFF
--- a/plugins/livedesk-embed/gui-themes/themes/rhrnt-section/base-theme.less
+++ b/plugins/livedesk-embed/gui-themes/themes/rhrnt-section/base-theme.less
@@ -443,6 +443,12 @@
 								margin-left: 50px;
 							}
 						}
+						&.instagram {
+							.post-text {
+								/* instagram post text - descritpions and tags */
+								
+							}
+						}
 						&.twitter {
 							.post-core-content {
 								.lbclearfix();


### PR DESCRIPTION
No need for adding new class, the block can be hit by:
# livedesk-root .liveblog-container .liveblog-content

.liveblog-content-middle .liveblog-postlist li.instagram
.post-content-full .post-core-content .post-text
