### PR TITLE
Fix social share plugin

### DIFF
--- a/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
+++ b/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
@@ -39,6 +39,7 @@ define([
                 // the post in different social networks
                 view.share = function(e) {
                     e.preventDefault();
+                    e.stopPropagation();
 
                     var self = this,
                         item = self.$(e.target),

--- a/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
+++ b/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
@@ -43,10 +43,10 @@ define([
 
                     var self = this,
                         item = self.$(e.target),
-                        init = item.attr('data-init'),
+                        initialized = item.data('initialized'),
                         urlParams;
 
-                    if (init !== 'done') {
+                    if (!initialized) {
                         urlParams = socialUrlParams(self);
 
                         // Store the share urls for the different social networks
@@ -62,7 +62,7 @@ define([
                         // Bind events for social network buttons
                         bindShareButtonsEvents(self);
 
-                        item.attr('data-init', 'done');
+                        item.data('initialized', 1);
                     }
 
                     // Toggle visibility of social share box,

--- a/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
+++ b/plugins/embed/gui-resources/scripts/js/plugins/social-share.js
@@ -41,20 +41,28 @@ define([
                     e.preventDefault();
 
                     var self = this,
+                        item = self.$(e.target),
+                        init = item.attr('data-init'),
+                        urlParams;
+
+                    if (init !== 'done') {
                         urlParams = socialUrlParams(self);
 
-                    // Store the share urls for the different social networks
-                    self.socialShareUrls = socialUrls(urlParams);
+                        // Store the share urls for the different social networks
+                        self.socialShareUrls = socialUrls(urlParams);
 
-                    // Add the box after the social share link
-                    dust.renderThemed('themeBase/plugins/social-share',
-                        socialParams(urlParams),
-                        function(err, out) {
-                            self.$('[data-gimme="post.social-share-placeholder"]').append(out);
-                        });
+                        // Add the box after the social share link
+                        dust.renderThemed('themeBase/plugins/social-share',
+                            socialParams(urlParams),
+                            function(err, out) {
+                                self.$('[data-gimme="post.social-share-placeholder"]').append(out);
+                            });
 
-                    // Bind events for social network buttons
-                    bindShareButtonsEvents(self);
+                        // Bind events for social network buttons
+                        bindShareButtonsEvents(self);
+
+                        item.attr('data-init', 'done');
+                    }
 
                     // Toggle visibility of social share box,
                     // if the box is hidden, hide other share plugins markup too


### PR DESCRIPTION
Avoid repeated insertion of the social sharing links.

This enables layouts without absolute positioning for the "share-box" element.