### PR TITLE
LBSD-594 Problem with FB embed code

### DIFF
--- a/plugins/livedesk/gui-resources/scripts/js/providers/edit.js
+++ b/plugins/livedesk/gui-resources/scripts/js/providers/edit.js
@@ -226,6 +226,7 @@ define('providers/edit', [
 		renderFBEmbed: function() {
 			if (typeof(FB) != 'undefined') {
 	            FB.XFBML.parse();
+	            FB.Canvas.setSize({ width: 640, height: 480 });
 		    }
 		},
 		init: function()


### PR DESCRIPTION
Facebook post did not render when pasting the embed code in the 'edit'
provider. Found quick fix